### PR TITLE
Disable Rapido 'not found' links

### DIFF
--- a/cypress/e2e/search-results.cy.ts
+++ b/cypress/e2e/search-results.cy.ts
@@ -16,7 +16,9 @@ describe("Search Results", () => {
     it("does not display the Rapido 'still not found' link", () => {
       page.searchFor("baseball");
       cy.get("prm-search-result-list").should("be.visible");
-      cy.get("prm-ngrs-results-button").should("not.be.visible");
+      cy.get("prm-ngrs-results-button button#ill-request-link").should(
+        "not.exist"
+      );
     });
   });
 

--- a/cypress/e2e/search-results.cy.ts
+++ b/cypress/e2e/search-results.cy.ts
@@ -1,11 +1,24 @@
 import { SearchPage } from "../pages";
-import { inViews } from "../support/e2e";
+import { inViews, inAllViews } from "../support/e2e";
 import { View } from "@src/view-code";
 
 // TODO: ArchivesSpace availability?
 
 describe("Search Results", () => {
   let page: SearchPage;
+
+  inAllViews((view) => {
+    before(() => {
+      page = new SearchPage(view);
+      page.visit();
+    });
+
+    it("does not display the Rapido 'still not found' link", () => {
+      page.searchFor("baseball");
+      cy.get("prm-search-result-list").should("be.visible");
+      cy.get("prm-ngrs-results-button").should("not.be.visible");
+    });
+  });
 
   inViews([View.TWINCITIES, View.DULUTH, View.MORRIS], (view) => {
     before(() => {

--- a/src/shared/components/search/full-view/full-view.module.ts
+++ b/src/shared/components/search/full-view/full-view.module.ts
@@ -2,8 +2,9 @@ import "./full-view.scss";
 import "./recommendations.scss";
 
 import { GetItModule } from "./get-it";
+import { NgrsModule } from "./ngrs";
 import { PrmServiceDetailsAfterComponent } from "./prm-service-details-after.component";
 
 export const FullViewModule = angular
-  .module("fullView", [GetItModule])
+  .module("fullView", [GetItModule, NgrsModule])
   .component("prmServiceDetailsAfter", PrmServiceDetailsAfterComponent).name;

--- a/src/shared/components/search/full-view/ngrs/index.ts
+++ b/src/shared/components/search/full-view/ngrs/index.ts
@@ -1,0 +1,1 @@
+export * from "./ngrs.module";

--- a/src/shared/components/search/full-view/ngrs/ngrs.module.ts
+++ b/src/shared/components/search/full-view/ngrs/ngrs.module.ts
@@ -1,0 +1,8 @@
+import { PrmNgrsResultsButtonAfterComponent } from "./prm-ngrs-results-button-after.component";
+
+export const NgrsModule = angular
+  .module("ngrs", [])
+  .component(
+    "prmNgrsResultsButtonAfter",
+    PrmNgrsResultsButtonAfterComponent
+  ).name;

--- a/src/shared/components/search/full-view/ngrs/prm-ngrs-results-button-after.component.ts
+++ b/src/shared/components/search/full-view/ngrs/prm-ngrs-results-button-after.component.ts
@@ -1,0 +1,22 @@
+class PrmNgrsResultsButtonAfterController implements ng.IController {
+  private parentCtrl: ng.IController;
+
+  $onInit(): void {
+    this.disableStillNotFoundLink();
+  }
+
+  /**
+   * By default, Rapido will display a link to a blank resource sharing
+   * request form. This disables the link.
+   */
+  private disableStillNotFoundLink(): void {
+    if (this.parentCtrl.isStillNotFoundRequired()) {
+      this.parentCtrl.isRapidoLinksTileRequired = () => false;
+    }
+  }
+}
+
+export const PrmNgrsResultsButtonAfterComponent: ng.IComponentOptions = {
+  controller: PrmNgrsResultsButtonAfterController,
+  bindings: { parentCtrl: "<" },
+};


### PR DESCRIPTION
Conditionally hide the Rapido search results banner so that it does not display links to the resource sharing request form.