### PR TITLE
Require Rapido home delivery address

### DIFF
--- a/src/shared/components/search/full-view/ngrs/ngrs.module.ts
+++ b/src/shared/components/search/full-view/ngrs/ngrs.module.ts
@@ -1,7 +1,9 @@
 import { PrmNgrsResultsButtonAfterComponent } from "./prm-ngrs-results-button-after.component";
+import { PrmGetItRequestAfterComponent } from "./prm-get-it-request-after.component";
 
 export const NgrsModule = angular
   .module("ngrs", [])
+  .component("prmGetItRequestAfter", PrmGetItRequestAfterComponent)
   .component(
     "prmNgrsResultsButtonAfter",
     PrmNgrsResultsButtonAfterComponent

--- a/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.spec.ts
+++ b/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.spec.ts
@@ -1,0 +1,56 @@
+import { NgrsModule } from "./ngrs.module";
+import { PrmGetItRequestAfterController } from "./prm-get-it-request-after.component";
+
+describe("prmGetItRequestAfterComponent", () => {
+  let $componentController: ng.IComponentControllerService;
+  let ctrl: PrmGetItRequestAfterController;
+  const parentCtrl: ng.IController = {
+    formData: {},
+    noteField: {
+      label: "nui.ngrs.request.note",
+      mandatory: false,
+    },
+    locationField: {
+      options: [
+        { label: "Library A", value: "1" },
+        { label: "Library B", value: "2" },
+        { label: "Library C", value: "3" },
+        { label: "Home Address", value: "4" },
+      ],
+    },
+  };
+
+  beforeEach(() => {
+    angular.mock.module(NgrsModule);
+    angular.mock.inject(($injector) => {
+      $componentController = $injector.get("$componentController");
+    });
+    ctrl = $componentController("prmGetItRequestAfter", null, {
+      parentCtrl: parentCtrl,
+    });
+    parentCtrl.formData.myLocation = "1";
+  });
+
+  it("adds an event listener to the location field", () => {
+    ctrl.$onInit();
+    expect(parentCtrl.locationField.events.onChange).toBeDefined();
+  });
+
+  it("enables a mandatory address field when Home Address is selected", () => {
+    ctrl.$onInit();
+    parentCtrl.formData.myLocation = "4";
+    parentCtrl.locationField.events.onChange();
+    expect(parentCtrl.noteField.mandatory).toBeTrue();
+    expect(parentCtrl.noteField.label).toEqual(
+      "umn.almaRequest.homeDeliveryAddress"
+    );
+  });
+
+  it("disables a mandatory address field when Home Address is not selected", () => {
+    ctrl.$onInit();
+    parentCtrl.formData.myLocation = "1";
+    parentCtrl.locationField.events.onChange();
+    expect(parentCtrl.noteField.mandatory).toBeFalse();
+    expect(parentCtrl.noteField.label).toEqual("nui.ngrs.request.note");
+  });
+});

--- a/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.ts
+++ b/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.ts
@@ -1,0 +1,71 @@
+export interface FormField {
+  key: string;
+  name: string;
+  label: string;
+  value?: string;
+  mandatory?: boolean;
+  options?: [
+    {
+      category: string;
+      label: string;
+      value: string;
+    }
+  ];
+  events?: {
+    onChange?: Function;
+  };
+}
+
+/**
+ * Binds an event listener to the Rapido physical request form's pickup
+ * location field. If a user selects "Home Address" the notes field is
+ * set to mandatory and its label is changed.
+ */
+export class PrmGetItRequestAfterController implements ng.IController {
+  private parentCtrl: ng.IController;
+
+  constructor() {
+    this.findLocationOption = _.memoize(this.findLocationOption);
+  }
+
+  $onInit(): void {
+    this.locationField.events = {
+      onChange: () => this.setMandatoryFields(),
+    };
+  }
+
+  private setMandatoryFields() {
+    if (this.isLocationSelected("Home Address")) {
+      this.noteField.mandatory = true;
+      this.noteField.label = "umn.almaRequest.homeDeliveryAddress";
+    } else {
+      this.noteField.mandatory = false;
+      this.noteField.label = "nui.ngrs.request.note";
+    }
+  }
+
+  private findLocationOption(label: string) {
+    return this.locationField.options.find((o: any) => o.label === label);
+  }
+
+  private isLocationSelected(location: string): boolean {
+    // The values associated with each label appear to be auto-generated, and
+    // it's not clear if they're stable over time. To be safe, we're looking
+    // up the values by label here.
+    const option = this.findLocationOption(location);
+    return this.parentCtrl.formData.myLocation === option.value;
+  }
+
+  get locationField(): FormField {
+    return this.parentCtrl.locationField;
+  }
+
+  get noteField(): FormField {
+    return this.parentCtrl.noteField;
+  }
+}
+
+export const PrmGetItRequestAfterComponent: ng.IComponentOptions = {
+  controller: PrmGetItRequestAfterController,
+  bindings: { parentCtrl: "<" },
+};


### PR DESCRIPTION
If a user selects "Home Address" as a pickup location in the Rapido physical copy request form, require a delivery address to be supplied in the form's note field.