### PR TITLE
Set default rapido pickup location

### DIFF
--- a/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.spec.ts
+++ b/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.spec.ts
@@ -64,4 +64,9 @@ describe("prmGetItRequestAfterComponent", () => {
     expect(parentCtrl.noteField.mandatory).toBeFalse();
     expect(parentCtrl.noteField.label).toEqual("nui.ngrs.request.note");
   });
+
+  it("sets the parent controller's default location to null", () => {
+    ctrl.$onInit();
+    expect(parentCtrl.getDefaultValue()).toBeNull();
+  });
 });

--- a/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.ts
+++ b/src/shared/components/search/full-view/ngrs/prm-get-it-request-after.component.ts
@@ -29,6 +29,7 @@ export class PrmGetItRequestAfterController implements ng.IController {
   }
 
   $onInit(): void {
+    this.overrideDefaultLocation();
     this.locationField.events = {
       onChange: () => this.setMandatoryFields(),
     };
@@ -57,6 +58,10 @@ export class PrmGetItRequestAfterController implements ng.IController {
     // up the values by label here.
     const option = this.findLocationOption(location);
     return this.parentCtrl.formData.myLocation === option.value;
+  }
+
+  private overrideDefaultLocation(): void {
+    this.parentCtrl.getDefaultValue = (): void => null;
   }
 
   get locationField(): FormField {


### PR DESCRIPTION
Forces the pickup location to be null by default when making a Rapido physical request.