### PR TITLE
Replace stacks.lib names with apps.lib

### DIFF
--- a/src/views/01UMN_INST-TWINCITIES/components/account/custom-tiles/courses/courses.service.ts
+++ b/src/views/01UMN_INST-TWINCITIES/components/account/custom-tiles/courses/courses.service.ts
@@ -1,7 +1,7 @@
 import { Course, CoursesResponse } from "./courses.model";
 
 export class CoursesService {
-  static URL = "https://stacks.lib.umn.edu/userapi/current-user/courses";
+  static URL = "https://apps.lib.umn.edu/userapi/current-user/courses";
 
   static $inject = ["$http", "$q", "$log"];
   constructor(

--- a/src/views/01UMN_INST-TWINCITIES/components/shib-auth/shib-auth.module.ts
+++ b/src/views/01UMN_INST-TWINCITIES/components/shib-auth/shib-auth.module.ts
@@ -8,9 +8,9 @@ function run(shibAuthEvents: ShibAuthEventsService) {
 
 export const ShibAuthModule = angular
   .module("shibAuth", [])
-  .constant("shibAuthHost", "stacks.lib.umn.edu")
-  .constant("shibAuthTarget", "https://stacks.lib.umn.edu/userapi/autologincb")
-  .constant("shibAuthExpectedMsg", "stacks")
+  .constant("shibAuthHost", "apps.lib.umn.edu")
+  .constant("shibAuthTarget", "https://apps.lib.umn.edu/userapi/autologincb")
+  .constant("shibAuthExpectedMsg", "apps")
   .service("shibAuthEvents", ShibAuthEventsService)
   .component("shibAuth", ShibAuthComponent)
   .run(run).name;


### PR DESCRIPTION
Small PHP applications running on the stacks.lib cluster are moving to apps.lib. Stacks will go cloud and keep its name to power Janus searches.

The relevant PHP applications will run concurrently on stacks & apps at least through May 2025 so either will be able to serve the the shib auth and course list request. So this can be merged and rolled out whenever - no problem if it waits a while and no further coordination necessary.